### PR TITLE
Handle milliseconds

### DIFF
--- a/cli/commands/logs.py
+++ b/cli/commands/logs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 from datetime import datetime
 
 import click
@@ -74,6 +75,9 @@ def logs(follow, all, app):
         ts = log['timestamp']
         ts = ts[0:ts.rindex(':')] + ts[ts.rindex(':') + 1:]
         if all:
+            # Truncate milliseconds from the date
+            # (sometimes this appears, and sometimes it doesn't appear)
+            ts = re.sub(r'\.[0-9]*', '', ts)
             date = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S%z')
         else:
             date = datetime.strptime(ts, '%Y-%m-%d %H:%M:%S.%f%z')

--- a/cli/version.py
+++ b/cli/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-version = '0.5.1'
+version = '0.5.2'


### PR DESCRIPTION
Milliseconds sporadically appear when `asyncy logs --all` is used. This PR truncates milliseconds altogether, using regex.